### PR TITLE
Add GetProfilePosts Instagram map

### DIFF
--- a/src/sf/grid/social-media/posts.instagram.suma
+++ b/src/sf/grid/social-media/posts.instagram.suma
@@ -87,7 +87,7 @@ operation MapPost {
     attachments = [
       {
         url: post.media_url,
-        title: post.video_title || post.caption,
+        title: post.video_title,
         type: post.media_type
       }
     ]

--- a/src/sf/grid/social-media/posts.instagram.suma
+++ b/src/sf/grid/social-media/posts.instagram.suma
@@ -1,0 +1,94 @@
+// Instagram Graph API Reference: https://developers.facebook.com/docs/instagram-api
+// 
+
+profile = "social-media/posts@1.0"
+provider = "instagram"
+
+map GetProfilePosts {
+  apiVersion = 'v12.0'
+  profileId = input.profileId
+  after = undefined
+  before = undefined
+
+  // We need to pass information whether we are iterating forward (next), or backward (previous),
+  // but we use only the bare cursors, hence we need to enrich them with this info.
+  set if( input.page && input.page.startsWith('next:')) {
+    after = input.page.replace('next:','')
+  }
+
+  set if( input.page && input.page.startsWith('previous:')) {
+    before = input.page.replace('previous:','')
+  }
+
+  http GET "/{apiVersion}/{profileId}/media" {
+
+    request {
+      query {
+          access_token = parameters.accessToken
+          limit = 25
+          after = after
+          before = before
+          fields = 'id,caption,image_url,created_time,permalink_url'
+      }
+    }
+
+    response 200 "application/json" {
+      posts = call foreach(post of body.data) MapPost(post = post)
+
+      previousPage = undefined
+      nextPage = undefined
+
+      set if(body.paging && body.paging.previous && body.paging.cursors && body.paging.cursors.before) {
+        previousPage = 'previous:' + body.paging.cursors.before
+      }
+
+       set if(body.paging && body.paging.next && body.paging.cursors && body.paging.cursors.after) {
+        nextPage = 'next:' + body.paging.cursors.after
+      }
+
+      return map result {
+        previousPage = previousPage
+        nextPage = nextPage
+        posts = posts
+      }
+    }
+
+    response 400 "application/json" {
+      return map error {
+        title = "Bad request"
+        detail = body.error.message
+      }
+    }
+
+    response 401 "application/json" {
+      return map error {
+        title = "Unauthenticated"
+        detail = body.error.message
+      }
+    }
+
+    response 403 "application/json" {
+      return map error {
+        title = "Forbidden"
+        detail = body.error.message
+      }
+    }
+  }
+}
+
+operation MapPost {
+  post = args.post
+
+  return {
+    id = post.id
+    url = post.permalink_url
+    createdAt = post.created_time
+    text = post.caption
+    attachments = [
+      {
+        url: post.image_url,
+        title: post.caption
+      }
+    ]
+  }
+}

--- a/src/sf/grid/social-media/posts.instagram.suma
+++ b/src/sf/grid/social-media/posts.instagram.suma
@@ -28,7 +28,7 @@ map GetProfilePosts {
           limit = 25
           after = after
           before = before
-          fields = 'id,caption,image_url,created_time,permalink_url'
+          fields = 'id,caption,media_url,timestamp,permalink,video_title,type,media_type'
       }
     }
 
@@ -81,13 +81,14 @@ operation MapPost {
 
   return {
     id = post.id
-    url = post.permalink_url
-    createdAt = post.created_time
+    url = post.permalink
+    createdAt = post.timestamp
     text = post.caption
     attachments = [
       {
-        url: post.image_url,
-        title: post.caption
+        url: post.media_url,
+        title: post.video_title || post.caption,
+        type: post.media_type
       }
     ]
   }

--- a/src/views/profile-posts.ejs
+++ b/src/views/profile-posts.ejs
@@ -32,7 +32,7 @@
               <ul>
                <% for(const attachment of post.attachments) { %>
                 <li>
-                 <a href="<%= attachment.url %>"><%= attachment.title%></a>
+                 <a href="<%= attachment.url %>"><%= attachment.title || post.text%></a>
                 </li>
               <% } %> 
               </ul>

--- a/superface/super.json
+++ b/superface/super.json
@@ -44,6 +44,9 @@
       "providers": {
         "facebook": {
           "file": "../src/sf/grid/social-media/posts.facebook.suma"
+        },
+        "instagram": {
+          "file": "../src/sf/grid/social-media/posts.instagram.suma"
         }
       }
     }


### PR DESCRIPTION
This PR adds GetProfilePosts Comlink map for Instagram provider.

According to Instagram [docs](https://developers.facebook.com/docs/instagram-api/reference/ig-user/media#reading) the media listing endpoint should use time based pagination. But in the reality it uses cursor based pagination.
