### PR TITLE
fix(auth): Merge user data upon verification

### DIFF
--- a/src/auth/facebook/auth.js
+++ b/src/auth/facebook/auth.js
@@ -1,4 +1,5 @@
 const FacebookStrategy = require('passport-facebook').Strategy;
+const { createVerifyCallback } = require('../utils');
 
 module.exports = function () {
   return new FacebookStrategy(
@@ -6,19 +7,8 @@ module.exports = function () {
       clientID: process.env.FACEBOOK_CLIENT_ID,
       clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
       callbackURL: `${process.env.BASE_URL}/auth/facebook/callback`,
+      passReqToCallback: true,
     },
-    function (accessToken, refreshToken, profile, done) {
-      // asynchronous verification, for effect...
-      process.nextTick(function () {
-        // To keep the example simple, the user's Facebook profile is returned to
-        // represent the logged-in user.  In a typical application, you would want
-        // to associate the Facebook account with a user record in your database,
-        // and return that user instead.
-        return done(null, {
-          displayName: profile.displayName,
-          facebook: { profile, accessToken, refreshToken },
-        });
-      });
-    }
+    createVerifyCallback()
   );
 };

--- a/src/auth/linkedin/auth.js
+++ b/src/auth/linkedin/auth.js
@@ -1,4 +1,5 @@
 const LinkedInStrategy = require('passport-linkedin-oauth2').Strategy;
+const { createVerifyCallback } = require('../utils');
 
 module.exports = function buildLinkedInStrategy() {
   return new LinkedInStrategy(
@@ -8,19 +9,8 @@ module.exports = function buildLinkedInStrategy() {
       callbackURL: `${process.env.BASE_URL}/auth/linkedin/callback`,
       // https://github.com/auth0/passport-linkedin-oauth2#auto-handle-state-param
       state: true,
+      passReqToCallback: true,
     },
-    function (accessToken, refreshToken, profile, done) {
-      // asynchronous verification, for effect...
-      process.nextTick(function () {
-        // To keep the example simple, the user's LinkedIn profile is returned to
-        // represent the logged-in user. In a typical application, you would want
-        // to associate the LinkedIn account with a user record in your database,
-        // and return that user instead.
-        return done(null, {
-          displayName: profile.displayName,
-          linkedin: { profile, accessToken, refreshToken },
-        });
-      });
-    }
+    createVerifyCallback()
   );
 };

--- a/src/auth/twitter/auth.js
+++ b/src/auth/twitter/auth.js
@@ -1,4 +1,5 @@
 const TwitterStrategy = require('./strategy');
+const { createVerifyCallback } = require('../utils');
 
 module.exports = function () {
   return new TwitterStrategy(
@@ -6,19 +7,8 @@ module.exports = function () {
       clientID: process.env.TWITTER_CLIENT_ID,
       clientSecret: process.env.TWITTER_CLIENT_SECRET,
       callbackURL: `${process.env.BASE_URL}/auth/twitter/callback`,
+      passReqToCallback: true,
     },
-    function (accessToken, refreshToken, profile, done) {
-      // asynchronous verification, for effect...
-      process.nextTick(function () {
-        // To keep the example simple, the user's Twitter profile is returned to
-        // represent the logged-in user.  In a typical application, you would want
-        // to associate the Twitter account with a user record in your database,
-        // and return that user instead.
-        return done(null, {
-          displayName: profile.displayName,
-          twitter: { profile, accessToken, refreshToken },
-        });
-      });
-    }
+    createVerifyCallback()
   );
 };

--- a/src/auth/utils.js
+++ b/src/auth/utils.js
@@ -1,0 +1,31 @@
+function createVerifyCallback() {
+  return function verifyCallback(
+    req,
+    accessToken,
+    refreshToken,
+    profile,
+    done
+  ) {
+    if (!done) {
+      throw new TypeError(
+        'Missing req in verifyCallback; did you enable passReqToCallback in your strategy?'
+      );
+    }
+    const provider = profile.provider;
+    if (!provider) {
+      throw new TypeError('Missing strategy provider name');
+    }
+    const existingUser = req.user || {};
+    // To keep the example simple, the user's profile is returned to
+    // represent the logged-in user. In a typical application, you would want
+    // to associate the provider's account with a user record in your database,
+    // and return that user instead.
+    return done(null, {
+      ...existingUser,
+      displayName: profile.displayName,
+      [provider]: { profile, accessToken, refreshToken },
+    });
+  };
+}
+
+module.exports = { createVerifyCallback };


### PR DESCRIPTION
Currently the data in `req.user` get overwriten by whatever the last login has been made.

This fix unifies the verify callback across strategies, and with help of `passReqToCallback` merges data from `req.user` during the verification. The `profile.provider` is used as key in `req.user` which isn't very robust but good enough for now.