### PR TITLE
fix: linkedin publishing-profiles map loading profile without logo

### DIFF
--- a/src/sf/grid/social-media/publishing-profiles.linkedin.suma
+++ b/src/sf/grid/social-media/publishing-profiles.linkedin.suma
@@ -60,6 +60,8 @@ map GetProfilesForPublishing {
 operation MapOrganization {
   org = args.element['organization~']
   orgLogo = null
+  logoElements = null
+  
   // If the profile is missing logo, the property logoV2 will be omitted
   set if (org.logoV2 && org.logoV2['cropped~']) {
     logoElements = org.logoV2['cropped~'].elements


### PR DESCRIPTION
This PR fixes jessie script error when loading profile without logo:

![image](https://user-images.githubusercontent.com/5206165/150763703-e00bac70-4e16-443d-a394-f15fe9e04ff2.png)

LinkedIn API response:

![image](https://user-images.githubusercontent.com/5206165/150764754-f67432c0-0ccd-4f01-9221-a5c00a967358.png)
