### PR TITLE
fix: Use logged in provider as default

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ const config = require('./config');
 const {
   getAccessTokenByProviderName,
   ensureAuthenticated,
+  getDefaultProvider,
 } = require('./utils');
 
 // Passport session setup.
@@ -84,7 +85,7 @@ app.get('/login', function (req, res) {
 });
 
 app.get('/publish-post', ensureAuthenticated, async function (req, res, next) {
-  const providerName = req.query.provider || 'facebook';
+  const providerName = req.query.provider || getDefaultProvider(req);
   let profiles = [];
   try {
     const accessToken = getAccessTokenByProviderName(providerName, req);

--- a/src/profile-posts.js
+++ b/src/profile-posts.js
@@ -1,11 +1,11 @@
 const { getProfilePosts, getProfilesForPublishing } = require('./sf/use-cases');
-const { getAccessTokenByProviderName } = require('./utils');
+const { getAccessTokenByProviderName, getDefaultProvider } = require('./utils');
 
 module.exports = async function getProfilePostsRoute(req, res, next) {
   let { provider, profileId, page } = req.query;
 
   if (!provider) {
-    provider = 'facebook';
+    provider = getDefaultProvider(req);
   }
 
   let profiles = undefined;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const { providers } = require('./config');
+
 function getAccessTokenByProviderName(providerName, req) {
   switch (providerName) {
     case 'facebook':
@@ -6,6 +8,17 @@ function getAccessTokenByProviderName(providerName, req) {
     default:
       return req.user[providerName]?.accessToken;
   }
+}
+
+function getDefaultProvider(req) {
+  //default provider is the first logged in provider
+  for (provider of providers) {
+    if (req.user[provider.id]) {
+      return provider.id;
+    }
+  }
+
+  return 'facebook'; //fallback to facebook if no provider is logged in
 }
 
 // Simple route middleware to ensure user is authenticated.
@@ -23,4 +36,5 @@ function ensureAuthenticated(req, res, next) {
 module.exports = {
   getAccessTokenByProviderName,
   ensureAuthenticated,
+  getDefaultProvider,
 };


### PR DESCRIPTION
This PR fixes following scenario:
- user starts demo app
- user logs on using Twitter account
- user goes to `Publish post` page
- boom
![image](https://user-images.githubusercontent.com/5206165/151330062-cbcace77-a3de-497a-a7f9-5222f5e3db75.png)

Instead of using Facebook as default provider for `Publish post` page first logged in provider is used.
