### PR TITLE
feat(publish): Fetch media from URL for perform

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@superfaceai/passport-twitter-oauth2": "^1.0.0",
     "body-parser": "^1.19.1",
     "cookie-parser": "^1.4.6",
+    "cross-fetch": "^3.1.5",
     "dotenv": "^16.0.0",
     "ejs": "^3.1.6",
     "express": "^4.17.2",

--- a/src/sf/use-cases.js
+++ b/src/sf/use-cases.js
@@ -1,3 +1,4 @@
+const fetch = require('cross-fetch');
 const sdk = require('./sdk');
 
 const ALLOWED_PROVIDERS = new Set([
@@ -26,14 +27,42 @@ async function getProfilesForPublishing(providerName, accessToken) {
   return result.unwrap()?.profiles;
 }
 
+// Lists providers which require files to be uploaded (i.e. can't just pass an URL for them to fetch)
+// FIXME: this should be exposed via dedicated use-case in the profile
+const PROVIDERS_FOR_UPLOAD = new Set(['linkedin', 'twitter']);
+
+// Array<{url: string, altText?: string}> => Array<{contents: Buffer, altText?: string}>
+async function fetchMedia(media) {
+  return Promise.all(
+    media.map(async (mediaItem) => {
+      if (mediaItem.contents) {
+        return mediaItem;
+      }
+      if (!mediaItem.url) {
+        throw new Error('Media without url nor contents');
+      }
+      const res = await fetch(mediaItem.url);
+      const buffer = await res.buffer();
+      return {
+        ...mediaItem,
+        contents: buffer,
+      };
+    })
+  );
+}
+
 async function publishPost(providerName, input, accessToken) {
   const profile = await sdk.getProfile('social-media/publish-post');
 
   const provider = await sdk.getProvider(providerName);
+  let { media } = input;
+  if (media?.length && PROVIDERS_FOR_UPLOAD.has(providerName)) {
+    media = await fetchMedia(media);
+  }
 
   const result = await profile
     .getUseCase('PublishPost')
-    .perform(input, { provider, parameters: { accessToken } });
+    .perform({ ...input, media }, { provider, parameters: { accessToken } });
 
   return result.unwrap();
 }

--- a/src/views/publish-post.ejs
+++ b/src/views/publish-post.ejs
@@ -2,7 +2,8 @@
   Publish to:
   <a href="?provider=facebook">Facebook</a> |
   <a href="?provider=instagram">Instagram</a> |
-  <a href="?provider=twitter">Twitter</a>
+  <a href="?provider=twitter">Twitter</a> |
+  <a href="?provider=linkedin">LinkedIn</a>
 </nav>
 
 <main>

--- a/superface/super.json
+++ b/superface/super.json
@@ -5,7 +5,8 @@
       "providers": {
         "instagram": {},
         "facebook": {},
-        "twitter": {}
+        "twitter": {},
+        "linkedin": {}
       }
     },
     "social-media/publishing-profiles": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,13 @@ cross-fetch@^3.0.5:
   dependencies:
     node-fetch "2.6.1"
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
@@ -938,6 +945,13 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 nodemon@^2.0.15:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.15.tgz#504516ce3b43d9dc9a955ccd9ec57550a31a8d4e"
@@ -1316,6 +1330,11 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -1354,7 +1373,6 @@ typescript-is@^0.18.3:
   integrity sha512-kBgZIJt3AKrtye1H2GYf9bWu1YS0Z9AZZl4OZG4z2Ps2jPMZuycilP9RkxPLP+tPxCUjXfmaJti9TNGoz5schA==
   dependencies:
     nested-error-stacks "^2"
-    reflect-metadata ">=0.1.12"
     tsutils "^3.17.1"
   optionalDependencies:
     reflect-metadata ">=0.1.12"
@@ -1439,6 +1457,19 @@ vm2@^3.9.2:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.5.tgz#5288044860b4bbace443101fcd3bddb2a0aa2496"
   integrity sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 widest-line@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Since only FB and Instagram allow passing the URL of images for publishing, this extends the existing use-case to fetch the image from the given URL into a buffer which is then passed to perform.